### PR TITLE
[Fabric] Convert UIColor to RCTUIColor shim

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
@@ -25,12 +25,12 @@ using namespace facebook::react;
 
     CGRect bounds = self.bounds;
     _label = [[UILabel alloc] initWithFrame:bounds];
-    _label.backgroundColor = [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.3];
+    _label.backgroundColor = [RCTUIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.3];
     _label.layoutMargins = UIEdgeInsetsMake(12, 12, 12, 12);
     _label.lineBreakMode = NSLineBreakByWordWrapping;
     _label.numberOfLines = 0;
     _label.textAlignment = NSTextAlignmentCenter;
-    _label.textColor = [UIColor whiteColor];
+    _label.textColor = [RCTUIColor whiteColor];
 
     self.contentView = _label;
   }

--- a/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
@@ -31,11 +31,11 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _label = [[UILabel alloc] initWithFrame:self.bounds];
-    _label.backgroundColor = [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.3];
+    _label.backgroundColor = [RCTUIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.3];
     _label.lineBreakMode = NSLineBreakByCharWrapping;
     _label.numberOfLines = 0;
     _label.textAlignment = NSTextAlignmentCenter;
-    _label.textColor = [UIColor whiteColor];
+    _label.textColor = [RCTUIColor whiteColor];
     _label.allowsDefaultTighteningForTruncation = YES;
     _label.adjustsFontSizeToFitWidth = YES;
 

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Provides access to `foregroundColor` prop of the component.
  * Must be used by subclasses only.
  */
-@property (nonatomic, strong, nullable) UIColor *foregroundColor;
+@property (nonatomic, strong, nullable) RCTUIColor *foregroundColor;
 
 /**
  * Returns the object - usually (sub)view - which represents this

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -21,7 +21,7 @@
 using namespace facebook::react;
 
 @implementation RCTViewComponentView {
-  UIColor *_backgroundColor;
+  RCTUIColor *_backgroundColor;
   CALayer *_borderLayer;
   BOOL _needsInvalidateLayer;
   BOOL _isJSResponder;
@@ -71,12 +71,12 @@ using namespace facebook::react;
   return CGRectContainsPoint(hitFrame, point);
 }
 
-- (UIColor *)backgroundColor
+- (RCTUIColor *)backgroundColor
 {
   return _backgroundColor;
 }
 
-- (void)setBackgroundColor:(UIColor *)backgroundColor
+- (void)setBackgroundColor:(RCTUIColor *)backgroundColor
 {
   _backgroundColor = backgroundColor;
 }

--- a/React/Fabric/RCTConversions.h
+++ b/React/Fabric/RCTConversions.h
@@ -35,26 +35,26 @@ inline std::string RCTStringFromNSString(NSString *string)
   return std::string{string.UTF8String ?: ""};
 }
 
-inline UIColor *_Nullable RCTUIColorFromSharedColor(facebook::react::SharedColor const &sharedColor)
+inline RCTUIColor *_Nullable RCTUIColorFromSharedColor(facebook::react::SharedColor const &sharedColor)
 {
   if (!sharedColor) {
     return nil;
   }
 
   if (*facebook::react::clearColor() == *sharedColor) {
-    return [UIColor clearColor];
+    return [RCTUIColor clearColor];
   }
 
   if (*facebook::react::blackColor() == *sharedColor) {
-    return [UIColor blackColor];
+    return [RCTUIColor blackColor];
   }
 
   if (*facebook::react::whiteColor() == *sharedColor) {
-    return [UIColor whiteColor];
+    return [RCTUIColor whiteColor];
   }
 
   auto components = facebook::react::colorComponentsFromColor(sharedColor);
-  return [UIColor colorWithRed:components.red green:components.green blue:components.blue alpha:components.alpha];
+  return [RCTUIColor colorWithRed:components.red green:components.green blue:components.blue alpha:components.alpha];
 }
 
 inline CF_RETURNS_RETAINED CGColorRef

--- a/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
+++ b/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
@@ -131,7 +131,7 @@ static NSDictionary<NSString *, NSDictionary *> *_PlatformColorSelectorsDict()
   return dict;
 }
 
-static UIColor *_UIColorFromHexValue(NSNumber *hexValue)
+static RCTUIColor *_UIColorFromHexValue(NSNumber *hexValue)
 {
   NSUInteger hexIntValue = [hexValue unsignedIntegerValue];
 
@@ -140,10 +140,10 @@ static UIColor *_UIColorFromHexValue(NSNumber *hexValue)
   CGFloat blue = ((CGFloat)((hexIntValue & 0xFF00) >> 8)) / 255.0;
   CGFloat alpha = ((CGFloat)(hexIntValue & 0xFF)) / 255.0;
 
-  return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+  return [RCTUIColor colorWithRed:red green:green blue:blue alpha:alpha];
 }
 
-static UIColor *_Nullable _UIColorFromSemanticString(NSString *semanticString)
+static RCTUIColor *_Nullable _UIColorFromSemanticString(NSString *semanticString)
 {
   NSString *platformColorString = [semanticString hasSuffix:kColorSuffix]
       ? [semanticString substringToIndex:[semanticString length] - [kColorSuffix length]]
@@ -152,17 +152,17 @@ static UIColor *_Nullable _UIColorFromSemanticString(NSString *semanticString)
   NSDictionary<NSString *, id> *colorInfo = platformColorSelectorsDict[platformColorString];
   if (colorInfo) {
     SEL objcColorSelector = NSSelectorFromString([platformColorString stringByAppendingString:kColorSuffix]);
-    if (![UIColor respondsToSelector:objcColorSelector]) {
+    if (![RCTUIColor respondsToSelector:objcColorSelector]) {
       NSNumber *fallbackRGB = colorInfo[kFallbackARGBKey];
       if (fallbackRGB) {
         return _UIColorFromHexValue(fallbackRGB);
       }
     } else {
-      Class uiColorClass = [UIColor class];
+      Class uiColorClass = [RCTUIColor class];
       IMP imp = [uiColorClass methodForSelector:objcColorSelector];
       id (*getUIColor)(id, SEL) = ((id(*)(id, SEL))imp);
       id colorObject = getUIColor(uiColorClass, objcColorSelector);
-      if ([colorObject isKindOfClass:[UIColor class]]) {
+      if ([colorObject isKindOfClass:[RCTUIColor class]]) {
         return colorObject;
       }
     }
@@ -177,7 +177,7 @@ static inline NSString *_NSStringFromCString(
   return [NSString stringWithCString:string.c_str() encoding:encoding];
 }
 
-static inline facebook::react::ColorComponents _ColorComponentsFromUIColor(UIColor *color)
+static inline facebook::react::ColorComponents _ColorComponentsFromUIColor(RCTUIColor *color)
 {
   CGFloat rgba[4];
   RCTGetRGBAColorComponents(color.CGColor, rgba);
@@ -188,7 +188,7 @@ facebook::react::ColorComponents RCTPlatformColorComponentsFromSemanticItems(std
 {
   for (const auto &semanticCString : semanticItems) {
     NSString *semanticNSString = _NSStringFromCString(semanticCString);
-    UIColor *uiColor = [UIColor colorNamed:semanticNSString];
+    RCTUIColor *uiColor = [RCTUIColor colorNamed:semanticNSString];
     if (uiColor != nil) {
       return _ColorComponentsFromUIColor(uiColor);
     }

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
@@ -83,9 +83,9 @@ inline static CGFloat RCTEffectiveFontSizeMultiplierFromTextAttributes(const Tex
       : 1.0;
 }
 
-inline static UIColor *RCTEffectiveForegroundColorFromTextAttributes(const TextAttributes &textAttributes)
+inline static RCTUIColor *RCTEffectiveForegroundColorFromTextAttributes(const TextAttributes &textAttributes)
 {
-  UIColor *effectiveForegroundColor = RCTUIColorFromSharedColor(textAttributes.foregroundColor) ?: [UIColor blackColor];
+  RCTUIColor *effectiveForegroundColor = RCTUIColorFromSharedColor(textAttributes.foregroundColor) ?: [RCTUIColor blackColor];
 
   if (!isnan(textAttributes.opacity)) {
     effectiveForegroundColor = [effectiveForegroundColor
@@ -95,16 +95,16 @@ inline static UIColor *RCTEffectiveForegroundColorFromTextAttributes(const TextA
   return effectiveForegroundColor;
 }
 
-inline static UIColor *RCTEffectiveBackgroundColorFromTextAttributes(const TextAttributes &textAttributes)
+inline static RCTUIColor *RCTEffectiveBackgroundColorFromTextAttributes(const TextAttributes &textAttributes)
 {
-  UIColor *effectiveBackgroundColor = RCTUIColorFromSharedColor(textAttributes.backgroundColor);
+  RCTUIColor *effectiveBackgroundColor = RCTUIColorFromSharedColor(textAttributes.backgroundColor);
 
   if (effectiveBackgroundColor && !isnan(textAttributes.opacity)) {
     effectiveBackgroundColor = [effectiveBackgroundColor
         colorWithAlphaComponent:CGColorGetAlpha(effectiveBackgroundColor.CGColor) * textAttributes.opacity];
   }
 
-  return effectiveBackgroundColor ?: [UIColor clearColor];
+  return effectiveBackgroundColor ?: [RCTUIColor clearColor];
 }
 
 NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(TextAttributes const &textAttributes)
@@ -118,7 +118,7 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(T
   }
 
   // Colors
-  UIColor *effectiveForegroundColor = RCTEffectiveForegroundColorFromTextAttributes(textAttributes);
+  RCTUIColor *effectiveForegroundColor = RCTEffectiveForegroundColorFromTextAttributes(textAttributes);
 
   if (textAttributes.foregroundColor || !isnan(textAttributes.opacity)) {
     attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
@@ -174,7 +174,7 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(T
     NSUnderlineStyle style = RCTNSUnderlineStyleFromTextDecorationStyle(
         textAttributes.textDecorationStyle.value_or(TextDecorationStyle::Solid));
 
-    UIColor *textDecorationColor = RCTUIColorFromSharedColor(textAttributes.textDecorationColor);
+    RCTUIColor *textDecorationColor = RCTUIColorFromSharedColor(textAttributes.textDecorationColor);
 
     // Underline
     if (textDecorationLineType == TextDecorationLineType::Underline ||

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextPrimitivesConversions.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextPrimitivesConversions.h
@@ -71,24 +71,24 @@ inline static NSUnderlineStyle RCTNSUnderlineStyleFromTextDecorationStyle(TextDe
   }
 }
 
-inline static UIColor *RCTUIColorFromSharedColor(const SharedColor &sharedColor)
+inline static RCTUIColor *RCTUIColorFromSharedColor(const SharedColor &sharedColor)
 {
   if (!sharedColor) {
     return nil;
   }
 
   if (*facebook::react::clearColor() == *sharedColor) {
-    return [UIColor clearColor];
+    return [RCTUIColor clearColor];
   }
 
   if (*facebook::react::blackColor() == *sharedColor) {
-    return [UIColor blackColor];
+    return [RCTUIColor blackColor];
   }
 
   if (*facebook::react::whiteColor() == *sharedColor) {
-    return [UIColor whiteColor];
+    return [RCTUIColor whiteColor];
   }
 
   auto components = facebook::react::colorComponentsFromColor(sharedColor);
-  return [UIColor colorWithRed:components.red green:components.green blue:components.blue alpha:components.alpha];
+  return [RCTUIColor colorWithRed:components.red green:components.green blue:components.blue alpha:components.alpha];
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:

Replacing references of UIColor to RCTUIColor shim

**NOTE:** This is based off of https://github.com/microsoft/react-native-macos/pull/1519 which has the RCTUIKit imports needed for this branch to work. Once that is merged, we will rebase this off `main`

## Changelog

[macOS][Fabric] - Replacing references of UIColor to RCTUIColor shim

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no UIColor errors
![CleanShot 2022-11-23 at 11 31 10](https://user-images.githubusercontent.com/96719/203632331-c2473131-d185-4607-a6cd-2f5c885fdb81.jpg)

Build errors: 
[Build RNTester-macOS_2022-11-23T11-29-34.txt](https://github.com/shwanton/react-native-macos/files/10078580/Build.RNTester-macOS_2022-11-23T11-29-34.txt)

[x] Build RNTester - iOS w/ Fabric - should work
https://user-images.githubusercontent.com/96719/203632474-0780ca3a-930f-4c2f-a76d-b60e31626750.mp4

[x] Build RNTester-macOS w/ Paper - should work
https://user-images.githubusercontent.com/96719/203632503-80e0ecfa-994c-4f86-9303-04621af6b4af.mp4

[x] Build RNTester - iOS w/ Paper - should work
https://user-images.githubusercontent.com/96719/203632520-fd512c31-abe0-4d95-90f3-ce8183e5d765.mp4