### PR TITLE
[Fabric] Convert UIView to RCTUIView shim

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <ActivityIndicator> component.
+ * RCTUIView class for root <ActivityIndicator> component.
  */
 @interface RCTActivityIndicatorViewComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <Image> component.
+ * RCTUIView class for root <Image> component.
  */
 @interface RCTImageComponentView : RCTViewComponentView <RCTImageResponseDelegate> {
  @protected

--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <InputAccessoryView> component.
+ * RCTUIView class for root <InputAccessoryView> component.
  */
 @interface RCTInputAccessoryComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -20,18 +20,18 @@
 
 using namespace facebook::react;
 
-static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNativeId(UIView *view, NSString *nativeId)
+static RCTUIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNativeId(RCTUIView *view, NSString *nativeId)
 {
   if ([view respondsToSelector:@selector(inputAccessoryViewID)] &&
       [view respondsToSelector:@selector(setInputAccessoryView:)]) {
-    UIView<RCTBackedTextInputViewProtocol> *typed = (UIView<RCTBackedTextInputViewProtocol> *)view;
+    RCTUIView<RCTBackedTextInputViewProtocol> *typed = (RCTUIView<RCTBackedTextInputViewProtocol> *)view;
     if (!nativeId || [typed.inputAccessoryViewID isEqualToString:nativeId]) {
       return typed;
     }
   }
 
-  for (UIView *subview in view.subviews) {
-    UIView<RCTBackedTextInputViewProtocol> *result = RCTFindTextInputWithNativeId(subview, nativeId);
+  for (RCTUIView *subview in view.subviews) {
+    RCTUIView<RCTBackedTextInputViewProtocol> *result = RCTFindTextInputWithNativeId(subview, nativeId);
     if (result) {
       return result;
     }
@@ -44,7 +44,7 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   InputAccessoryShadowNode::ConcreteState::Shared _state;
   RCTInputAccessoryContentView *_contentView;
   RCTSurfaceTouchHandler *_touchHandler;
-  UIView<RCTBackedTextInputViewProtocol> __weak *_textInput;
+  RCTUIView<RCTBackedTextInputViewProtocol> __weak *_textInput;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -83,7 +83,7 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   return true;
 }
 
-- (UIView *)inputAccessoryView
+- (RCTUIView *)inputAccessoryView
 {
   return _contentView;
 }
@@ -95,12 +95,12 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   return concreteComponentDescriptorProvider<InputAccessoryComponentDescriptor>();
 }
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [_contentView insertSubview:childComponentView atIndex:index];
 }
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [childComponentView removeFromSuperview];
 }

--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.h
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.h
@@ -7,6 +7,6 @@
 
 #import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
-@interface RCTInputAccessoryContentView : UIView
+@interface RCTInputAccessoryContentView : RCTUIView
 
 @end

--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.mm
@@ -8,7 +8,7 @@
 #import "RCTInputAccessoryContentView.h"
 
 @implementation RCTInputAccessoryContentView {
-  UIView *_safeAreaContainer;
+  RCTUIView *_safeAreaContainer;
   NSLayoutConstraint *_heightConstraint;
 }
 
@@ -17,7 +17,7 @@
   if (self = [super init]) {
     self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
 
-    _safeAreaContainer = [UIView new];
+    _safeAreaContainer = [RCTUIView new];
     _safeAreaContainer.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_safeAreaContainer];
 
@@ -40,7 +40,7 @@
   return CGSizeZero;
 }
 
-- (void)insertSubview:(UIView *)view atIndex:(NSInteger)index
+- (void)insertSubview:(RCTUIView *)view atIndex:(NSInteger)index
 {
   [_safeAreaContainer insertSubview:view atIndex:index];
 }

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -22,7 +22,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 @implementation RCTLegacyViewManagerInteropComponentView {
   NSMutableArray<NSDictionary *> *_viewsToBeMounted;
-  NSMutableArray<UIView *> *_viewsToBeUnmounted;
+  NSMutableArray<RCTUIView *> *_viewsToBeUnmounted;
   RCTLegacyViewManagerInteropCoordinatorAdapter *_adapter;
   LegacyViewManagerInteropShadowNode::ConcreteState::Shared _state;
   BOOL _hasInvokedForwardingWarning;
@@ -41,9 +41,9 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   return self;
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
-  UIView *result = [super hitTest:point withEvent:event];
+  RCTUIView *result = [super hitTest:point withEvent:event];
 
   if (result == _adapter.paperView) {
     return self;
@@ -149,7 +149,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   [super prepareForRecycle];
 }
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [_viewsToBeMounted addObject:@{
     kRCTLegacyInteropChildIndexKey : [NSNumber numberWithInteger:index],
@@ -157,7 +157,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   }];
 }
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   if (_adapter) {
     [_adapter.paperView removeReactSubview:childComponentView];
@@ -208,7 +208,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
   [_viewsToBeMounted removeAllObjects];
 
-  for (UIView *view in _viewsToBeUnmounted) {
+  for (RCTUIView *view in _viewsToBeUnmounted) {
     [_adapter.paperView removeReactSubview:view];
   }
 

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.h
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithCoordinator:(RCTLegacyViewManagerInteropCoordinator *)coordinator reactTag:(NSInteger)tag;
 
-@property (strong, nonatomic) UIView *paperView;
+@property (strong, nonatomic) RCTUIView *paperView;
 
 @property (nonatomic, copy, nullable) void (^eventInterceptor)(std::string eventName, folly::dynamic event);
 

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
@@ -28,7 +28,7 @@
   [_coordinator removeObserveForTag:_tag];
 }
 
-- (UIView *)paperView
+- (RCTUIView *)paperView
 {
   if (!_paperView) {
     _paperView = [_coordinator createPaperViewWithTag:_tag];

--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.h
@@ -9,7 +9,7 @@
 #import <React/RCTViewComponentView.h>
 
 /**
- * UIView class for root <ModalHostView> component.
+ * RCTUIView class for root <ModalHostView> component.
  */
 @interface RCTModalHostViewComponentView : RCTViewComponentView <RCTMountingTransactionObserving>
 

--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -104,7 +104,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   BOOL _shouldAnimatePresentation;
   BOOL _shouldPresent;
   BOOL _isPresented;
-  UIView *_modalContentsSnapshot;
+  RCTUIView *_modalContentsSnapshot;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -165,7 +165,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
     _isPresented = NO;
     // To animate dismissal of view controller, snapshot of
     // view hierarchy needs to be added to the UIViewController.
-    UIView *snapshot = _modalContentsSnapshot;
+    RCTUIView *snapshot = _modalContentsSnapshot;
     [self.viewController.view addSubview:snapshot];
 
     [self dismissViewController:self.viewController
@@ -198,7 +198,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   _modalContentsSnapshot = [self.viewController.view snapshotViewAfterScreenUpdates:NO];
 }
 
-#pragma mark - UIView methods
+#pragma mark - RCTUIView methods
 
 - (void)didMoveToWindow
 {
@@ -269,12 +269,12 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   _state = std::static_pointer_cast<const ModalHostViewShadowNode::ConcreteState>(state);
 }
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [self.viewController.view insertSubview:childComponentView atIndex:index];
 }
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [childComponentView removeFromSuperview];
 }

--- a/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <View> component.
+ * RCTUIView class for root <View> component.
  */
 @interface RCTRootComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <SafeAreaView> component.
+ * RCTUIView class for root <SafeAreaView> component.
  */
 @interface RCTSafeAreaViewComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol RCTEnhancedScrollViewOverridingDelegate <NSObject>
 
-- (BOOL)touchesShouldCancelInContentView:(UIView *)view;
+- (BOOL)touchesShouldCancelInContentView:(RCTUIView *)view;
 
 @end
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -88,7 +88,7 @@
       RCTSanitizeNaNValue(contentOffset.y, @"scrollView.contentOffset.y"));
 }
 
-- (BOOL)touchesShouldCancelInContentView:(UIView *)view
+- (BOOL)touchesShouldCancelInContentView:(RCTUIView *)view
 {
   if ([_overridingDelegate respondsToSelector:@selector(touchesShouldCancelInContentView:)]) {
     return [_overridingDelegate touchesShouldCancelInContentView:view];

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*
- * UIView class for root <PullToRefreshView> component.
+ * RCTUIView class for root <PullToRefreshView> component.
  * This view is designed to only serve ViewController-like purpose for the actual `UIRefreshControl` view which is being
  * attached to some `UIScrollView` (not to this view).
  */

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
@@ -16,7 +16,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*
- * UIView class for <ScrollView> component.
+ * RCTUIView class for <ScrollView> component.
  *
  * By design, the class does not implement any logic that contradicts to the normal behavior of UIScrollView and does
  * not contain any special/custom support for things like floating headers, pull-to-refresh components,
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Finds and returns the closet RCTScrollViewComponentView component to the given view
  */
-+ (nullable RCTScrollViewComponentView *)findScrollViewComponentViewForView:(UIView *)view;
++ (nullable RCTScrollViewComponentView *)findScrollViewComponentViewForView:(RCTUIView *)view;
 
 /*
  * Returns an actual UIScrollView that this component uses under the hood.
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  * separate component views from auxiliary views to be able to reliably implement pull-to-refresh- and RTL-related
  * functionality.
  */
-@property (nonatomic, strong, readonly) UIView *containerView;
+@property (nonatomic, strong, readonly) RCTUIView *containerView;
 
 /*
  * Returns a delegate splitter that can be used to subscribe for UIScrollView delegate.

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -102,7 +102,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   CGPoint _contentOffsetWhenClipped;
 }
 
-+ (RCTScrollViewComponentView *_Nullable)findScrollViewComponentViewForView:(UIView *)view
++ (RCTScrollViewComponentView *_Nullable)findScrollViewComponentViewForView:(RCTUIView *)view
 {
   do {
     view = view.superview;
@@ -124,7 +124,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     _shouldUpdateContentInsetAdjustmentBehavior = YES;
     [self addSubview:_scrollView];
 
-    _containerView = [[UIView alloc] initWithFrame:CGRectZero];
+    _containerView = [[RCTUIView alloc] initWithFrame:CGRectZero];
     [_scrollView addSubview:_containerView];
 
     [self.scrollViewDelegateSplitter addDelegate:self];
@@ -334,12 +334,12 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   [((RCTEnhancedScrollView *)_scrollView) preserveContentOffsetWithBlock:block];
 }
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [_containerView insertSubview:childComponentView atIndex:index];
 }
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [childComponentView removeFromSuperview];
 }
@@ -350,11 +350,11 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
  */
 - (BOOL)_shouldDisableScrollInteraction
 {
-  UIView *ancestorView = self.superview;
+  RCTUIView *ancestorView = self.superview;
 
   while (ancestorView) {
     if ([ancestorView respondsToSelector:@selector(isJSResponder)]) {
-      BOOL isJSResponder = ((UIView<RCTComponentViewProtocol> *)ancestorView).isJSResponder;
+      BOOL isJSResponder = ((RCTUIView<RCTComponentViewProtocol> *)ancestorView).isJSResponder;
       if (isJSResponder) {
         return YES;
       }
@@ -409,7 +409,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 #pragma mark - UIScrollViewDelegate
 
-- (BOOL)touchesShouldCancelInContentView:(__unused UIView *)view
+- (BOOL)touchesShouldCancelInContentView:(__unused RCTUIView *)view
 {
   // Historically, `UIScrollView`s in React Native do not cancel touches
   // started on `UIControl`-based views (as normal iOS `UIScrollView`s do).
@@ -519,7 +519,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   [self _updateStateWithContentOffset];
 }
 
-- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view
+- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(nullable RCTUIView *)view
 {
   [self _forceDispatchNextScrollEvent];
 
@@ -530,7 +530,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   std::static_pointer_cast<ScrollViewEventEmitter const>(_eventEmitter)->onScrollBeginDrag([self _scrollViewMetrics]);
 }
 
-- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view atScale:(CGFloat)scale
+- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable RCTUIView *)view atScale:(CGFloat)scale
 {
   [self _forceDispatchNextScrollEvent];
 
@@ -542,7 +542,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   [self _updateStateWithContentOffset];
 }
 
-- (UIView *)viewForZoomingInScrollView:(__unused UIScrollView *)scrollView
+- (RCTUIView *)viewForZoomingInScrollView:(__unused UIScrollView *)scrollView
 {
   return _containerView;
 }
@@ -610,7 +610,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 #pragma mark - Child views mounting
 
-- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(UIView *)clipView
+- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(RCTUIView *)clipView
 {
   // Do nothing. ScrollView manages its subview clipping individually in `_remountChildren`.
 }

--- a/React/Fabric/Mounting/ComponentViews/Slider/RCTSliderComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Slider/RCTSliderComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <Slider> component.
+ * RCTUIView class for root <Slider> component.
  */
 @interface RCTSliderComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for root <Switch> component.
+ * RCTUIView class for root <Switch> component.
  */
 @interface RCTSwitchComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.mm
@@ -11,7 +11,7 @@
 
 - (CGRect)accessibilityFrame
 {
-  UIView *container = (UIView *)self.accessibilityContainer;
+  RCTUIView *container = (RCTUIView *)self.accessibilityContainer;
   if (CGRectEqualToRect(_frame, CGRectZero)) {
     return UIAccessibilityConvertFrameToScreenCoordinates(container.bounds, container);
   } else {

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.h
@@ -19,7 +19,7 @@
                  layoutManager:(RCTTextLayoutManager *)layoutManager
            paragraphAttributes:(facebook::react::ParagraphAttributes)paragraphAttributes
                          frame:(CGRect)frame
-                          view:(UIView *)view;
+                          view:(RCTUIView *)view;
 
 /*
  * Returns an array of `UIAccessibilityElement`s to be used for `UIAccessibilityContainer` implementation.

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm
@@ -26,14 +26,14 @@ using namespace facebook::react;
   RCTTextLayoutManager *_layoutManager;
   ParagraphAttributes _paragraphAttributes;
   CGRect _frame;
-  __weak UIView *_view;
+  __weak RCTUIView *_view;
 }
 
 - (instancetype)initWithString:(facebook::react::AttributedString)attributedString
                  layoutManager:(RCTTextLayoutManager *)layoutManager
            paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                          frame:(CGRect)frame
-                          view:(UIView *)view
+                          view:(RCTUIView *)view
 {
   if (self = [super init]) {
     _attributedString = attributedString;

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*
- * UIView class for <Paragraph> component.
+ * RCTUIView class for <Paragraph> component.
  */
 @interface RCTParagraphComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for <TextInput> component.
+ * RCTUIView class for <TextInput> component.
  */
 @interface RCTTextInputComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -30,7 +30,7 @@ using namespace facebook::react;
 
 @implementation RCTTextInputComponentView {
   TextInputShadowNode::ConcreteState::Shared _state;
-  UIView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
+  RCTUIView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
   NSUInteger _mostRecentEventCount;
   NSAttributedString *_lastStringStateWasUpdatedWith;
 
@@ -58,7 +58,7 @@ using namespace facebook::react;
   BOOL _didMoveToWindow;
 }
 
-#pragma mark - UIView overrides
+#pragma mark - RCTUIView overrides
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -603,7 +603,7 @@ using namespace facebook::react;
 - (void)_setMultiline:(BOOL)multiline
 {
   [_backedTextInputView removeFromSuperview];
-  UIView<RCTBackedTextInputViewProtocol> *backedTextInputView = multiline ? [RCTUITextView new] : [RCTUITextField new];
+  RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView = multiline ? [RCTUITextView new] : [RCTUITextField new];
   backedTextInputView.frame = _backedTextInputView.frame;
   RCTCopyBackedTextInput(_backedTextInputView, backedTextInputView);
   _backedTextInputView = backedTextInputView;

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -15,8 +15,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 void RCTCopyBackedTextInput(
-    UIView<RCTBackedTextInputViewProtocol> *fromTextInput,
-    UIView<RCTBackedTextInputViewProtocol> *toTextInput);
+    RCTUIView<RCTBackedTextInputViewProtocol> *fromTextInput,
+    RCTUIView<RCTBackedTextInputViewProtocol> *toTextInput);
 
 UITextAutocorrectionType RCTUITextAutocorrectionTypeFromOptionalBool(std::optional<bool> autoCorrect);
 

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -19,8 +19,8 @@ static NSAttributedString *RCTSanitizeAttributedString(NSAttributedString *attri
 }
 
 void RCTCopyBackedTextInput(
-    UIView<RCTBackedTextInputViewProtocol> *fromTextInput,
-    UIView<RCTBackedTextInputViewProtocol> *toTextInput)
+    RCTUIView<RCTBackedTextInputViewProtocol> *fromTextInput,
+    RCTUIView<RCTBackedTextInputViewProtocol> *toTextInput)
 {
   toTextInput.attributedText = RCTSanitizeAttributedString(fromTextInput.attributedText);
   toTextInput.placeholder = fromTextInput.placeholder;

--- a/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*
- * UIView class for all kinds of <UnimplementedView> components.
+ * RCTUIView class for all kinds of <UnimplementedView> components.
  */
 @interface RCTUnimplementedViewComponentView : RCTViewComponentView
 

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -20,9 +20,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * UIView class for <View> component.
+ * RCTUIView class for <View> component.
  */
-@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol> {
+@interface RCTViewComponentView : RCTUIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol> {
  @protected
   facebook::react::LayoutMetrics _layoutMetrics;
   facebook::react::SharedViewProps _props;
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  * to embed/bridge pure native views as component views.
  * Defaults to `nil`. Assign `nil` to remove view as subview.
  */
-@property (nonatomic, strong, nullable) UIView *contentView;
+@property (nonatomic, strong, nullable) RCTUIView *contentView;
 
 /**
  * Provides access to `nativeId` prop of the component.

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -26,7 +26,7 @@ using namespace facebook::react;
   BOOL _needsInvalidateLayer;
   BOOL _isJSResponder;
   BOOL _removeClippedSubviews;
-  NSMutableArray<UIView *> *_reactSubviews;
+  NSMutableArray<RCTUIView *> *_reactSubviews;
   NSSet<NSString *> *_Nullable _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 }
 
@@ -48,7 +48,7 @@ using namespace facebook::react;
   return _props;
 }
 
-- (void)setContentView:(UIView *)contentView
+- (void)setContentView:(RCTUIView *)contentView
 {
   if (_contentView) {
     [_contentView removeFromSuperview];
@@ -92,7 +92,7 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<ViewComponentDescriptor>();
 }
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   RCTAssert(
       childComponentView.superview == nil,
@@ -109,7 +109,7 @@ using namespace facebook::react;
   }
 }
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   if (_removeClippedSubviews) {
     [_reactSubviews removeObjectAtIndex:index];
@@ -133,7 +133,7 @@ using namespace facebook::react;
   [childComponentView removeFromSuperview];
 }
 
-- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(UIView *)clipView
+- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(RCTUIView *)clipView
 {
   if (!_removeClippedSubviews) {
     // Use default behavior if unmounting is disabled
@@ -154,7 +154,7 @@ using namespace facebook::react;
   clipRect = [clipView convertRect:clipRect toView:self];
 
   // Mount / unmount views
-  for (UIView *view in _reactSubviews) {
+  for (RCTUIView *view in _reactSubviews) {
     if (CGRectIntersectsRect(clipRect, view.frame)) {
       // View is at least partially visible, so remount it if unmounted
       [self addSubview:view];
@@ -438,7 +438,7 @@ using namespace facebook::react;
   return _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 }
 
-- (UIView *)betterHitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)betterHitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
   // This is a classic textbook implementation of `hitTest:` with a couple of improvements:
   //   * It does not stop algorithm if some touch is outside the view
@@ -460,8 +460,8 @@ using namespace facebook::react;
     return nil;
   }
 
-  for (UIView *subview in [self.subviews reverseObjectEnumerator]) {
-    UIView *hitView = [subview hitTest:[subview convertPoint:point fromView:self] withEvent:event];
+  for (RCTUIView *subview in [self.subviews reverseObjectEnumerator]) {
+    RCTUIView *hitView = [subview hitTest:[subview convertPoint:point fromView:self] withEvent:event];
     if (hitView) {
       return hitView;
     }
@@ -470,7 +470,7 @@ using namespace facebook::react;
   return isPointInside ? self : nil;
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
   switch (_props->pointerEvents) {
     case PointerEventsMode::Auto:
@@ -480,7 +480,7 @@ using namespace facebook::react;
     case PointerEventsMode::BoxOnly:
       return [self pointInside:point withEvent:event] ? self : nil;
     case PointerEventsMode::BoxNone:
-      UIView *view = [self betterHitTest:point withEvent:event];
+      RCTUIView *view = [self betterHitTest:point withEvent:event];
       return view != self ? view : nil;
   }
 }
@@ -662,10 +662,10 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
   return self;
 }
 
-static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
+static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view)
 {
   NSMutableString *result = [NSMutableString stringWithString:@""];
-  for (UIView *subview in view.subviews) {
+  for (RCTUIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);

--- a/React/Fabric/Mounting/RCTComponentViewDescriptor.h
+++ b/React/Fabric/Mounting/RCTComponentViewDescriptor.h
@@ -21,7 +21,7 @@ class RCTComponentViewDescriptor final {
   /*
    * Associated (and owned) native view instance.
    */
-  __strong UIView<RCTComponentViewProtocol> *view = nil;
+  __strong RCTUIView<RCTComponentViewProtocol> *view = nil;
 
   /*
    * Indicates a requirement to call on the view methods from

--- a/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -54,14 +54,14 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
  * component view.
  * Receiver must add `childComponentView` as a subview.
  */
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
 
 /*
  * Called for unmounting (detaching) a child component view from `self`
  * component view.
  * Receiver must remove `childComponentView` as a subview.
  */
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
 
 /*
  * Called for updating component's props.

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.h
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Finds a native component view by given `tag`.
  * Returns `nil` if there is no registered component with the `tag`.
  */
-- (nullable UIView<RCTComponentViewProtocol> *)findComponentViewWithTag:(facebook::react::Tag)tag;
+- (nullable RCTUIView<RCTComponentViewProtocol> *)findComponentViewWithTag:(facebook::react::Tag)tag;
 
 /**
  * Creates a component view with a given type and puts it to the recycle pool.

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -116,7 +116,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   return iterator->second;
 }
 
-- (nullable UIView<RCTComponentViewProtocol> *)findComponentViewWithTag:(Tag)tag
+- (nullable RCTUIView<RCTComponentViewProtocol> *)findComponentViewWithTag:(Tag)tag
 {
   RCTAssertMainQueue();
   auto iterator = _registry.find(tag);

--- a/React/Fabric/Mounting/RCTMountingManager.h
+++ b/React/Fabric/Mounting/RCTMountingManager.h
@@ -36,12 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
  * influence the intrinsic size of the view and cannot be measured using UIView/UIKit layout API.
  * Must be called on the main thead.
  */
-- (void)attachSurfaceToView:(UIView *)view surfaceId:(facebook::react::SurfaceId)surfaceId;
+- (void)attachSurfaceToView:(RCTUIView *)view surfaceId:(facebook::react::SurfaceId)surfaceId;
 
 /**
  * Stops designating the view as a rendering viewport of a React Native surface.
  */
-- (void)detachSurfaceFromView:(UIView *)view surfaceId:(facebook::react::SurfaceId)surfaceId;
+- (void)detachSurfaceFromView:(RCTUIView *)view surfaceId:(facebook::react::SurfaceId)surfaceId;
 
 /**
  * Schedule a mounting transaction to be performed on the main thread.

--- a/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/React/Fabric/Mounting/RCTMountingManager.mm
@@ -29,7 +29,7 @@
 
 using namespace facebook::react;
 
-static SurfaceId RCTSurfaceIdForView(UIView *view)
+static SurfaceId RCTSurfaceIdForView(RCTUIView *view)
 {
   do {
     if (RCTIsReactRootView(@(view.tag))) {
@@ -81,7 +81,7 @@ static void RCTPerformMountInstructions(
         auto &newChildViewDescriptor = [registry componentViewDescriptorWithTag:newChildShadowView.tag];
         auto &parentViewDescriptor = [registry componentViewDescriptorWithTag:parentShadowView.tag];
 
-        UIView<RCTComponentViewProtocol> *newChildComponentView = newChildViewDescriptor.view;
+        RCTUIView<RCTComponentViewProtocol> *newChildComponentView = newChildViewDescriptor.view;
 
         RCTAssert(newChildShadowView.props, @"`newChildShadowView.props` must not be null.");
 
@@ -109,7 +109,7 @@ static void RCTPerformMountInstructions(
         auto &oldChildShadowView = mutation.oldChildShadowView;
         auto &newChildShadowView = mutation.newChildShadowView;
         auto &newChildViewDescriptor = [registry componentViewDescriptorWithTag:newChildShadowView.tag];
-        UIView<RCTComponentViewProtocol> *newChildComponentView = newChildViewDescriptor.view;
+        RCTUIView<RCTComponentViewProtocol> *newChildComponentView = newChildViewDescriptor.view;
 
         auto mask = RNComponentViewUpdateMask{};
 
@@ -168,7 +168,7 @@ static void RCTPerformMountInstructions(
   _contextContainer = contextContainer;
 }
 
-- (void)attachSurfaceToView:(UIView *)view surfaceId:(SurfaceId)surfaceId
+- (void)attachSurfaceToView:(RCTUIView *)view surfaceId:(SurfaceId)surfaceId
 {
   RCTAssertMainQueue();
 
@@ -179,7 +179,7 @@ static void RCTPerformMountInstructions(
   [view addSubview:rootViewDescriptor.view];
 }
 
-- (void)detachSurfaceFromView:(UIView *)view surfaceId:(SurfaceId)surfaceId
+- (void)detachSurfaceFromView:(RCTUIView *)view surfaceId:(SurfaceId)surfaceId
 {
   RCTAssertMainQueue();
   RCTComponentViewDescriptor rootViewDescriptor = [_componentViewRegistry componentViewDescriptorWithTag:surfaceId];
@@ -287,7 +287,8 @@ static void RCTPerformMountInstructions(
 {
   ReactTag reactTag = shadowView.tag;
   RCTExecuteOnMainQueue(^{
-    UIView<RCTComponentViewProtocol> *componentView = [self->_componentViewRegistry findComponentViewWithTag:reactTag];
+    RCTUIView<RCTComponentViewProtocol> *componentView =
+        [self->_componentViewRegistry findComponentViewWithTag:reactTag];
     [componentView setIsJSResponder:isJSResponder];
   });
 }
@@ -297,7 +298,7 @@ static void RCTPerformMountInstructions(
                       componentDescriptor:(const ComponentDescriptor &)componentDescriptor
 {
   RCTAssertMainQueue();
-  UIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
+  RCTUIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
   SurfaceId surfaceId = RCTSurfaceIdForView(componentView);
   Props::Shared oldProps = [componentView props];
   Props::Shared newProps = componentDescriptor.cloneProps(
@@ -331,14 +332,14 @@ static void RCTPerformMountInstructions(
                                           args:(NSArray *)args
 {
   RCTAssertMainQueue();
-  UIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
+  RCTUIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
   [componentView handleCommand:commandName args:args];
 }
 
 - (void)synchronouslyDispatchAccessbilityEventOnUIThread:(ReactTag)reactTag eventType:(NSString *)eventType
 {
   if ([@"focus" isEqualToString:eventType]) {
-    UIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
+    RCTUIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, componentView);
   }
 }

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -14,13 +14,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Default implementation of RCTComponentViewProtocol.
  */
-@interface UIView (ComponentViewProtocol) <RCTComponentViewProtocol>
+@interface RCTUIView (ComponentViewProtocol) <RCTComponentViewProtocol>
 
 + (std::vector<facebook::react::ComponentDescriptorProvider>)supplementalComponentDescriptorProviders;
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
 
 - (void)updateProps:(facebook::react::Props::Shared const &)props
            oldProps:(facebook::react::Props::Shared const &)oldProps;
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(nullable NSSet<NSString *> *)props;
 - (nullable NSSet<NSString *> *)propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 
-- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(UIView *)clipView;
+- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(RCTUIView *)clipView;
 
 @end
 

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -15,7 +15,7 @@
 
 using namespace facebook::react;
 
-@implementation UIView (ComponentViewProtocol)
+@implementation RCTUIView (ComponentViewProtocol)
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
@@ -28,7 +28,7 @@ using namespace facebook::react;
   return {};
 }
 
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)mountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   RCTAssert(
       childComponentView.superview == nil,
@@ -40,7 +40,7 @@ using namespace facebook::react;
   [self insertSubview:childComponentView atIndex:index];
 }
 
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+- (void)unmountChildComponentView:(RCTUIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   RCTAssert(
       childComponentView.superview == self,
@@ -156,14 +156,14 @@ using namespace facebook::react;
   return nil;
 }
 
-- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(UIView *)clipView
+- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(RCTUIView *)clipView
 {
   clipRect = [clipView convertRect:clipRect toView:self];
 
   // Normal views don't support unmounting, so all
   // this does is forward message to our subviews,
   // in case any of those do support it
-  for (UIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) {
     [subview updateClippedSubviewsWithClipRect:clipRect relativeToView:self];
   }
 }

--- a/React/Fabric/RCTSurfacePresenter.h
+++ b/React/Fabric/RCTSurfacePresenter.h
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Please do not use this, this will be deleted soon.
  */
-- (nullable UIView *)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag;
+- (nullable RCTUIView *)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag;
 
 @end
 

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -171,9 +171,9 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
                                           initialProperties:initialProperties];
 }
 
-- (UIView *)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag
+- (RCTUIView *)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag
 {
-  UIView<RCTComponentViewProtocol> *componentView =
+  RCTUIView<RCTComponentViewProtocol> *componentView =
       [_mountingManager.componentViewRegistry findComponentViewWithTag:tag];
   return componentView;
 }
@@ -186,7 +186,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   }
 
   ReactTag tag = [reactTag integerValue];
-  UIView<RCTComponentViewProtocol> *componentView =
+  RCTUIView<RCTComponentViewProtocol> *componentView =
       [_mountingManager.componentViewRegistry findComponentViewWithTag:tag];
   if (componentView == nil) {
     return NO; // This view probably isn't managed by Fabric

--- a/React/Fabric/RCTSurfaceTouchHandler.h
+++ b/React/Fabric/RCTSurfaceTouchHandler.h
@@ -15,8 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Attaches (and detaches) a view to the touch handler.
  * The receiver does not retain the provided view.
  */
-- (void)attachToView:(UIView *)view;
-- (void)detachFromView:(UIView *)view;
+- (void)attachToView:(RCTUIView *)view;
+- (void)detachFromView:(RCTUIView *)view;
 
 /*
  * Offset of the attached view relative to the root component in points.

--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -60,7 +60,7 @@ struct ActiveTouch {
   /*
    * A component view on which the touch was begun.
    */
-  __strong UIView<RCTComponentViewProtocol> *componentView = nil;
+  __strong RCTUIView<RCTComponentViewProtocol> *componentView = nil;
 
   struct Hasher {
     size_t operator()(const ActiveTouch &activeTouch) const
@@ -80,7 +80,7 @@ struct ActiveTouch {
 static void UpdateActiveTouchWithUITouch(
     ActiveTouch &activeTouch,
     UITouch *uiTouch,
-    UIView *rootComponentView,
+    RCTUIView *rootComponentView,
     CGPoint rootViewOriginOffset)
 {
   CGPoint offsetPoint = [uiTouch locationInView:activeTouch.componentView];
@@ -99,12 +99,12 @@ static void UpdateActiveTouchWithUITouch(
   }
 }
 
-static ActiveTouch CreateTouchWithUITouch(UITouch *uiTouch, UIView *rootComponentView, CGPoint rootViewOriginOffset)
+static ActiveTouch CreateTouchWithUITouch(UITouch *uiTouch, RCTUIView *rootComponentView, CGPoint rootViewOriginOffset)
 {
   ActiveTouch activeTouch = {};
 
   // Find closest Fabric-managed touchable view
-  UIView *componentView = uiTouch.view;
+  RCTUIView *componentView = uiTouch.view;
   while (componentView) {
     if ([componentView respondsToSelector:@selector(touchEventEmitterAtPoint:)]) {
       activeTouch.eventEmitter = [(id<RCTTouchableComponentViewProtocol>)componentView
@@ -164,7 +164,7 @@ struct PointerHasher {
   /*
    * We hold the view weakly to prevent a retain cycle.
    */
-  __weak UIView *_rootComponentView;
+  __weak RCTUIView *_rootComponentView;
   IdentifierPool<11> _identifierPool;
 }
 
@@ -187,7 +187,7 @@ struct PointerHasher {
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)action)
 
-- (void)attachToView:(UIView *)view
+- (void)attachToView:(RCTUIView *)view
 {
   RCTAssert(self.view == nil, @"RCTTouchHandler already has attached view.");
 
@@ -195,7 +195,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   _rootComponentView = view;
 }
 
-- (void)detachFromView:(UIView *)view
+- (void)detachFromView:(RCTUIView *)view
 {
   RCTAssertParam(view);
   RCTAssert(self.view == view, @"RCTTouchHandler attached to another view.");

--- a/React/Fabric/Surface/RCTFabricSurface.h
+++ b/React/Fabric/Surface/RCTFabricSurface.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The primary goals of the RCTSurface are:
  *  * ability to measure and layout the surface in a thread-safe
  *    and synchronous manner;
- *  * ability to create a UIView instance on demand (later);
+ *  * ability to create a RCTUIView instance on demand (later);
  *  * ability to communicate the current stage of the surface granularly.
  */
 @interface RCTFabricSurface : NSObject <RCTSurfaceProtocol>
@@ -47,12 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)resetWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter;
 
-#pragma mark - Dealing with UIView representation, the Main thread only access
+#pragma mark - Dealing with RCTUIView representation, the Main thread only access
 
 /**
  * Creates (if needed) and returns `UIView` instance which represents the Surface.
  * The Surface will cache and *retain* this object.
- * Returning the UIView instance does not mean that the Surface is ready
+ * Returning the RCTUIView instance does not mean that the Surface is ready
  * to execute and layout. It can be just a handler which Surface will use later
  * to mount the actual views.
  * RCTSurface does not control (or influence in any way) the size or origin

--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -16,7 +16,7 @@
 
 @protocol RCTModalHostViewInteractor;
 
-@interface RCTModalHostView : UIView <RCTInvalidating, UIAdaptivePresentationControllerDelegate>
+@interface RCTModalHostView : RCTUIView <RCTInvalidating, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, copy) NSString *animationType;
 @property (nonatomic, assign) UIModalPresentationStyle presentationStyle;

--- a/React/Views/RCTWeakViewHolder.h
+++ b/React/Views/RCTWeakViewHolder.h
@@ -14,6 +14,6 @@
  */
 @protocol RCTWeakViewHolder
 
-@property (nonatomic, strong) NSMapTable<NSNumber *, UIView *> *weakViews;
+@property (nonatomic, strong) NSMapTable<NSNumber *, RCTUIView *> *weakViews;
 
 @end

--- a/React/Views/RCTWrapperViewController.h
+++ b/React/Views/RCTWrapperViewController.h
@@ -11,6 +11,6 @@
 
 @interface RCTWrapperViewController : UIViewController
 
-- (instancetype)initWithContentView:(UIView *)contentView NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithContentView:(RCTUIView *)contentView NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/React/Views/UIView+React.h
+++ b/React/Views/UIView+React.h
@@ -29,7 +29,7 @@
 
 /**
  * Determines whether or not a view should ignore inverted colors or not. Used to set
- * UIView property accessibilityIgnoresInvertColors in iOS 11+.
+ * RCTUIView property accessibilityIgnoresInvertColors in iOS 11+.
  */
 @property (nonatomic, assign) BOOL shouldAccessibilityIgnoresInvertColors;
 

--- a/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -20,13 +20,13 @@ typedef void (^InterceptorBlock)(std::string eventName, folly::dynamic event);
 
 - (instancetype)initWithComponentData:(RCTComponentData *)componentData bridge:(RCTBridge *)bridge;
 
-- (UIView *)createPaperViewWithTag:(NSInteger)tag;
+- (RCTUIView *)createPaperViewWithTag:(NSInteger)tag;
 
 - (void)addObserveForTag:(NSInteger)tag usingBlock:(InterceptorBlock)block;
 
 - (void)removeObserveForTag:(NSInteger)tag;
 
-- (void)setProps:(folly::dynamic const &)props forView:(UIView *)view;
+- (void)setProps:(folly::dynamic const &)props forView:(RCTUIView *)view;
 
 - (NSString *)componentViewName;
 

--- a/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -27,7 +27,7 @@ using namespace facebook::react;
   __weak RCTBridge *_bridge;
   /*
    Each instance of `RCTLegacyViewManagerInteropComponentView` registers a block to which events are dispatched.
-   This is the container that maps unretained UIView pointer to a block to which the event is dispatched.
+   This is the container that maps unretained RCTUIView pointer to a block to which the event is dispatched.
    */
   NSMutableDictionary<NSNumber *, InterceptorBlock> *_eventInterceptors;
 
@@ -71,9 +71,9 @@ using namespace facebook::react;
   [_eventInterceptors removeObjectForKey:[NSNumber numberWithInteger:tag]];
 }
 
-- (UIView *)createPaperViewWithTag:(NSInteger)tag;
+- (RCTUIView *)createPaperViewWithTag:(NSInteger)tag;
 {
-  UIView *view = [_componentData createViewWithTag:[NSNumber numberWithInteger:tag] rootTag:NULL];
+  RCTUIView *view = [_componentData createViewWithTag:[NSNumber numberWithInteger:tag] rootTag:NULL];
   if ([_componentData.bridgelessViewManager conformsToProtocol:@protocol(RCTWeakViewHolder)]) {
     id<RCTWeakViewHolder> weakViewHolder = (id<RCTWeakViewHolder>)_componentData.bridgelessViewManager;
     if (!weakViewHolder.weakViews) {
@@ -84,7 +84,7 @@ using namespace facebook::react;
   return view;
 }
 
-- (void)setProps:(folly::dynamic const &)props forView:(UIView *)view
+- (void)setProps:(folly::dynamic const &)props forView:(RCTUIView *)view
 {
   if (props.isObject()) {
     NSDictionary<NSString *, id> *convertedProps = convertFollyDynamicToId(props);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:

Replacing references of UIView to RCTUIView shim

**NOTE:** #1519 adds the RCTUIKit imports required for this branch. Once that is merged, this PR will not have those changes.

## Changelog

[macOS][Fabric] - Replacing references of UIView to RCTUIView shim

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no UIView errors
![CleanShot 2022-11-23 at 13 04 18](https://user-images.githubusercontent.com/96719/203646814-59bdd9b0-d655-4a5d-b408-bb40e692c1d0.jpg)

[Build RNTester-macOS_2022-11-23T13-02-55.txt](https://github.com/shwanton/react-native-macos/files/10079190/Build.RNTester-macOS_2022-11-23T13-02-55.txt)

[x] Build RNTester - iOS w/ Fabric - should work
https://user-images.githubusercontent.com/96719/203647093-7d05dff3-760a-4053-9d4b-164d133482aa.mp4

[x] Build RNTester-macOS w/ Paper - should work
https://user-images.githubusercontent.com/96719/203647140-a37bbc9e-53b1-4628-b1e7-7c4a14754c58.mp4


[x] Build RNTester - iOS w/ Paper - should work
https://user-images.githubusercontent.com/96719/203646958-e64d1c13-580f-446d-8b87-d452f7c38932.mp4

